### PR TITLE
Fix timestep embedding scale for continuous timesteps (0–1 range)

### DIFF
--- a/dit.py
+++ b/dit.py
@@ -19,7 +19,7 @@ class TimestepEmbedder(nn.Module):
         self.nfreq = nfreq
 
     @staticmethod
-    def timestep_embedding(t, dim, max_period=10000):
+    def timestep_embedding(t, dim, max_period=10):
         half_dim = dim // 2
         freqs = torch.exp(
             -math.log(max_period)


### PR DESCRIPTION
The previous implementation likely caused the timestep embeddings to lose effectiveness when timesteps were normalized to the [0, 1] range. The default max_period=10000 was inherited from diffusion-based models, but it results in almost constant embeddings under this scale.

This update adjusts the embedding scale (or rescales timesteps) to ensure proper sinusoidal variation for continuous-time settings such as flow matching. In my experiments, models using the original setting showed noticeably higher FID scores compared to UNet baselines — this issue might have contributed to that gap.